### PR TITLE
New fix for issue #5, fix buttons

### DIFF
--- a/OBSMidi/nanoKontrol2OBS/Kontrol2OBS.cs
+++ b/OBSMidi/nanoKontrol2OBS/Kontrol2OBS.cs
@@ -140,23 +140,20 @@ namespace nanoKontrol2OBS
                 switch (operation.action)
                 {
                     case Config.action.nexttrack:
-                        if (e.value == 127)
                             keybd_event(0xB0, 0, 1, IntPtr.Zero);
                         break;
                     case Config.action.previoustrack:
-                        if (e.value == 127)
                             keybd_event(0xB1, 0, 1, IntPtr.Zero);
                         break;
                     case Config.action.playpause:
-                        if (e.value == 127)
                             keybd_event(0xB3, 0, 1, IntPtr.Zero);
                         break;
                     case Config.action.obsmute:
-                        if (this.specialSources[operation.source].connected && e.value == 127)
+                        if (this.specialSources[operation.source].connected)
                             this.obsSocket.ToggleMute(this.specialSources[operation.source].obsSourceName);
                         break;
                     case Config.action.windowsmute:
-                        if (this.specialSources[operation.source].connected && e.value == 127)
+                        if (this.specialSources[operation.source].connected)
                             this.specialSources[operation.source].windowsDevice.ToggleMute();
                         break;
                     case Config.action.setobsvolume:
@@ -168,20 +165,15 @@ namespace nanoKontrol2OBS
                             this.specialSources[operation.source].windowsDevice.SetVolume(Convert.ToDouble(e.value).Map(0, 127, 0, 100));
                         break;
                     case Config.action.savereplay:
-                        if (e.value == 127)
                             this.obsSocket.SaveReplayBuffer();
                         break;
                     case Config.action.startstopstream:
-                        if (e.value == 127)
                             this.obsSocket.StartStopStreaming();
                         break;
                     case Config.action.switchscene:
-                        if (e.value == 127)
-                        {
                             Scene[] scenes = this.obsSocket.GetSceneList().scenes;
                             if (operation.index <= scenes.Length)
                                 this.obsSocket.SetCurrentScene(scenes[operation.index].name);
-                        }
                         break;
                 }
             }

--- a/OBSMidi/nanoKontrol2OBS/Kontrol2OBS.cs
+++ b/OBSMidi/nanoKontrol2OBS/Kontrol2OBS.cs
@@ -140,13 +140,13 @@ namespace nanoKontrol2OBS
                 switch (operation.action)
                 {
                     case Config.action.nexttrack:
-                            keybd_event(0xB0, 0, 1, IntPtr.Zero);
+                        keybd_event(0xB0, 0, 1, IntPtr.Zero);
                         break;
                     case Config.action.previoustrack:
-                            keybd_event(0xB1, 0, 1, IntPtr.Zero);
+                        keybd_event(0xB1, 0, 1, IntPtr.Zero);
                         break;
                     case Config.action.playpause:
-                            keybd_event(0xB3, 0, 1, IntPtr.Zero);
+                        keybd_event(0xB3, 0, 1, IntPtr.Zero);
                         break;
                     case Config.action.obsmute:
                         if (this.specialSources[operation.source].connected)
@@ -165,15 +165,15 @@ namespace nanoKontrol2OBS
                             this.specialSources[operation.source].windowsDevice.SetVolume(Convert.ToDouble(e.value).Map(0, 127, 0, 100));
                         break;
                     case Config.action.savereplay:
-                            this.obsSocket.SaveReplayBuffer();
+                        this.obsSocket.SaveReplayBuffer();
                         break;
                     case Config.action.startstopstream:
-                            this.obsSocket.StartStopStreaming();
+                        this.obsSocket.StartStopStreaming();
                         break;
                     case Config.action.switchscene:
-                            Scene[] scenes = this.obsSocket.GetSceneList().scenes;
-                            if (operation.index <= scenes.Length)
-                                this.obsSocket.SetCurrentScene(scenes[operation.index].name);
+                        Scene[] scenes = this.obsSocket.GetSceneList().scenes;
+                        if (operation.index <= scenes.Length)
+                            this.obsSocket.SetCurrentScene(scenes[operation.index].name);
                         break;
                 }
             }

--- a/OBSMidi/nanoKontrol2OBS/Kontrol2OBS.cs
+++ b/OBSMidi/nanoKontrol2OBS/Kontrol2OBS.cs
@@ -116,7 +116,7 @@ namespace nanoKontrol2OBS
         private void WindowsDevice_OnMuteStateChanged(object sender, AudioDevice.OnMuteStateChangedEventArgs e)
         {
             foreach (SpecialSourceObject potentialSender in this.specialSources.Values)
-                if (potentialSender.windowsDevice is null && potentialSender.windowsDevice.Equals(sender))
+                if (!(potentialSender.windowsDevice is null) && potentialSender.windowsDevice.Equals(sender))
                 {
                     if (potentialSender.specialSourceType.Equals(SpecialSourceType.desktop1))
                         this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.windowsmutechanged, SpecialSourceType.desktop1), e.muted);
@@ -140,20 +140,23 @@ namespace nanoKontrol2OBS
                 switch (operation.action)
                 {
                     case Config.action.nexttrack:
-                        keybd_event(0xB0, 0, 1, IntPtr.Zero);
+                        if (e.value == 127)
+                            keybd_event(0xB0, 0, 1, IntPtr.Zero);
                         break;
                     case Config.action.previoustrack:
-                        keybd_event(0xB1, 0, 1, IntPtr.Zero);
+                        if (e.value == 127)
+                            keybd_event(0xB1, 0, 1, IntPtr.Zero);
                         break;
                     case Config.action.playpause:
-                        keybd_event(0xB3, 0, 1, IntPtr.Zero);
+                        if (e.value == 127)
+                            keybd_event(0xB3, 0, 1, IntPtr.Zero);
                         break;
                     case Config.action.obsmute:
-                        if (this.specialSources[operation.source].connected)
+                        if (this.specialSources[operation.source].connected && e.value == 127)
                             this.obsSocket.ToggleMute(this.specialSources[operation.source].obsSourceName);
                         break;
                     case Config.action.windowsmute:
-                        if (this.specialSources[operation.source].connected)
+                        if (this.specialSources[operation.source].connected && e.value == 127)
                             this.specialSources[operation.source].windowsDevice.ToggleMute();
                         break;
                     case Config.action.setobsvolume:
@@ -165,15 +168,20 @@ namespace nanoKontrol2OBS
                             this.specialSources[operation.source].windowsDevice.SetVolume(Convert.ToDouble(e.value).Map(0, 127, 0, 100));
                         break;
                     case Config.action.savereplay:
-                        this.obsSocket.SaveReplayBuffer();
+                        if (e.value == 127)
+                            this.obsSocket.SaveReplayBuffer();
                         break;
                     case Config.action.startstopstream:
-                        this.obsSocket.StartStopStreaming();
+                        if (e.value == 127)
+                            this.obsSocket.StartStopStreaming();
                         break;
                     case Config.action.switchscene:
-                        Scene[] scenes = this.obsSocket.GetSceneList().scenes;
-                        if(operation.index <= scenes.Length)
-                            this.obsSocket.SetCurrentScene(scenes[operation.index].name);
+                        if (e.value == 127)
+                        {
+                            Scene[] scenes = this.obsSocket.GetSceneList().scenes;
+                            if (operation.index <= scenes.Length)
+                                this.obsSocket.SetCurrentScene(scenes[operation.index].name);
+                        }
                         break;
                 }
             }

--- a/OBSMidi/nanoKontrol2OBS/Kontrol2OBS.cs
+++ b/OBSMidi/nanoKontrol2OBS/Kontrol2OBS.cs
@@ -116,7 +116,7 @@ namespace nanoKontrol2OBS
         private void WindowsDevice_OnMuteStateChanged(object sender, AudioDevice.OnMuteStateChangedEventArgs e)
         {
             foreach (SpecialSourceObject potentialSender in this.specialSources.Values)
-                if (potentialSender.windowsDevice.Equals(sender))
+                if (potentialSender.windowsDevice is null && potentialSender.windowsDevice.Equals(sender))
                 {
                     if (potentialSender.specialSourceType.Equals(SpecialSourceType.desktop1))
                         this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.windowsmutechanged, SpecialSourceType.desktop1), e.muted);
@@ -248,8 +248,8 @@ namespace nanoKontrol2OBS
             this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.obsmutechanged, SpecialSourceType.mic2), this.specialSources[SpecialSourceType.mic2].connected ? !this.obsSocket.GetMute(this.specialSources[SpecialSourceType.mic2].obsSourceName) : false);
             this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.obsmutechanged, SpecialSourceType.mic3), this.specialSources[SpecialSourceType.mic3].connected ? !this.obsSocket.GetMute(this.specialSources[SpecialSourceType.mic3].obsSourceName) : false);
 
-            this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.windowsmutechanged, SpecialSourceType.desktop1), this.specialSources[SpecialSourceType.desktop2].connected ? this.specialSources[SpecialSourceType.desktop1].windowsDevice.IsMuted() : false);
-            this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.windowsmutechanged, SpecialSourceType.desktop2), this.specialSources[SpecialSourceType.desktop1].connected ? this.specialSources[SpecialSourceType.desktop2].windowsDevice.IsMuted() : false);
+            this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.windowsmutechanged, SpecialSourceType.desktop1), this.specialSources[SpecialSourceType.desktop1].connected ? this.specialSources[SpecialSourceType.desktop1].windowsDevice.IsMuted() : false);
+            this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.windowsmutechanged, SpecialSourceType.desktop2), this.specialSources[SpecialSourceType.desktop2].connected ? this.specialSources[SpecialSourceType.desktop2].windowsDevice.IsMuted() : false);
             this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.windowsmutechanged, SpecialSourceType.mic1), this.specialSources[SpecialSourceType.mic1].connected ? this.specialSources[SpecialSourceType.mic1].windowsDevice.IsMuted() : false);
             this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.windowsmutechanged, SpecialSourceType.mic2), this.specialSources[SpecialSourceType.mic2].connected ? this.specialSources[SpecialSourceType.mic2].windowsDevice.IsMuted() : false);
             this.nanoController.ToggleLED(this.bindingConfig.GetOutputToEvent(Config.outputevent.windowsmutechanged, SpecialSourceType.mic3), this.specialSources[SpecialSourceType.mic3].connected ? this.specialSources[SpecialSourceType.mic3].windowsDevice.IsMuted() : false);


### PR DESCRIPTION
I made a mistake in the previous fix for issue #5. It should have checked if the windows device was NOT null, but I somehow messed that up.

Buttons were also firing twice. Once with value 127 (button pressed) and again with value 0 (button released). I adjusted the code to only fire the action when the value is 127 (excluding volume adjustments)
